### PR TITLE
Database error with setAuthoredStory()

### DIFF
--- a/adventure.datetime/src/ca/cmput301f13t03/adventure_datetime/model/StoryDB.java
+++ b/adventure.datetime/src/ca/cmput301f13t03/adventure_datetime/model/StoryDB.java
@@ -532,8 +532,6 @@ public class StoryDB implements BaseColumns, ILocalStorage {
 
     @Override
     public boolean setAuthoredStory(Story story) {
-        SQLiteDatabase db = mDbHelper.getWritableDatabase();
-
         Story story2 = getStory(story.getId());
 
         if(story2 == null) {
@@ -545,6 +543,8 @@ public class StoryDB implements BaseColumns, ILocalStorage {
             Log.v(TAG, "Story already in AuthoredStory table");
             return true;
         }
+
+        SQLiteDatabase db = mDbHelper.getWritableDatabase();
 
         ContentValues values = new ContentValues();
 


### PR DESCRIPTION
StoryDB.setAuthoredStory() does not work when calling it on a new story, and throws the following exception when calling it on a downloaded story:

12-02 17:57:12.143: E/AndroidRuntime(30852): FATAL EXCEPTION: main
12-02 17:57:12.143: E/AndroidRuntime(30852): Process: ca.cmput301f13t03.adventure_datetime, PID: 30852
12-02 17:57:12.143: E/AndroidRuntime(30852): java.lang.IllegalStateException: attempt to re-open an already-closed object: SQLiteDatabase: /data/data/ca.cmput301f13t03.adventure_datetime/databases/adventure.database
12-02 17:57:12.143: E/AndroidRuntime(30852):    at android.database.sqlite.SQLiteClosable.acquireReference(SQLiteClosable.java:55)
12-02 17:57:12.143: E/AndroidRuntime(30852):    at android.database.sqlite.SQLiteDatabase.insertWithOnConflict(SQLiteDatabase.java:1437)
12-02 17:57:12.143: E/AndroidRuntime(30852):    at android.database.sqlite.SQLiteDatabase.insert(SQLiteDatabase.java:1339)
12-02 17:57:12.143: E/AndroidRuntime(30852):    at ca.cmput301f13t03.adventure_datetime.model.StoryDB.setAuthoredStory(StoryDB.java:558)
12-02 17:57:12.143: E/AndroidRuntime(30852):    at ca.cmput301f13t03.adventure_datetime.model.StoryManager.setStoryToAuthor(StoryManager.java:645)
12-02 17:57:12.143: E/AndroidRuntime(30852):    at ca.cmput301f13t03.adventure_datetime.controller.AuthorController.setStoryToAuthor(AuthorController.java:159)
12-02 17:57:12.143: E/AndroidRuntime(30852):    at ca.cmput301f13t03.adventure_datetime.view.StoryDescription.onOptionsItemSelected(StoryDescription.java:204)
12-02 17:57:12.143: E/AndroidRuntime(30852):    at android.app.Activity.onMenuItemSelected(Activity.java:2599)
12-02 17:57:12.143: E/AndroidRuntime(30852):    at com.android.internal.policy.impl.PhoneWindow.onMenuItemSelected(PhoneWindow.java:1012)
12-02 17:57:12.143: E/AndroidRuntime(30852):    at com.android.internal.view.menu.MenuBuilder.dispatchMenuItemSelected(MenuBuilder.java:735)
12-02 17:57:12.143: E/AndroidRuntime(30852):    at com.android.internal.view.menu.MenuItemImpl.invoke(MenuItemImpl.java:152)
12-02 17:57:12.143: E/AndroidRuntime(30852):    at com.android.internal.view.menu.MenuBuilder.performItemAction(MenuBuilder.java:874)
12-02 17:57:12.143: E/AndroidRuntime(30852):    at com.android.internal.view.menu.ActionMenuView.invokeItem(ActionMenuView.java:546)
12-02 17:57:12.143: E/AndroidRuntime(30852):    at com.android.internal.view.menu.ActionMenuItemView.onClick(ActionMenuItemView.java:115)
12-02 17:57:12.143: E/AndroidRuntime(30852):    at android.view.View.performClick(View.java:4424)
12-02 17:57:12.143: E/AndroidRuntime(30852):    at android.view.View$PerformClick.run(View.java:18383)
12-02 17:57:12.143: E/AndroidRuntime(30852):    at android.os.Handler.handleCallback(Handler.java:733)
12-02 17:57:12.143: E/AndroidRuntime(30852):    at android.os.Handler.dispatchMessage(Handler.java:95)
12-02 17:57:12.143: E/AndroidRuntime(30852):    at android.os.Looper.loop(Looper.java:137)
12-02 17:57:12.143: E/AndroidRuntime(30852):    at android.app.ActivityThread.main(ActivityThread.java:4998)
12-02 17:57:12.143: E/AndroidRuntime(30852):    at java.lang.reflect.Method.invokeNative(Native Method)
12-02 17:57:12.143: E/AndroidRuntime(30852):    at java.lang.reflect.Method.invoke(Method.java:515)
12-02 17:57:12.143: E/AndroidRuntime(30852):    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:777)
12-02 17:57:12.143: E/AndroidRuntime(30852):    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:593)
12-02 17:57:12.143: E/AndroidRuntime(30852):    at dalvik.system.NativeStart.main(Native Method)

Any idea why?
