### PR TITLE
Fixed bug with autocorrect in text edit

### DIFF
--- a/adventure.datetime/res/layout/choice_item.xml
+++ b/adventure.datetime/res/layout/choice_item.xml
@@ -1,37 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
-    android:layout_height="match_parent"
-    android:orientation="horizontal" >
+    android:layout_height="wrap_content"
+    android:orientation="horizontal">
 
     <EditText
         android:id="@+id/choice_txt"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textSize="24sp"
-        android:hint="Enter Choice"
-        android:gravity="center_vertical"
         android:layout_marginTop="5sp"
-        android:maxLength="22"/>
+        android:gravity="left"
+        android:hint="Enter Choice"
+        android:textSize="24sp" 
+        android:layout_weight="4"/>
 
-    <LinearLayout
-        android:layout_width="fill_parent"
+    <ImageButton
+        android:id="@+id/choices_edit_btn"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:gravity="right">
+        android:contentDescription="@string/btn_editChoice"
+        android:src="@drawable/ic_action_edit" 
+        android:layout_weight="1"/>
 
-        <ImageButton
-            android:id="@+id/choices_edit_btn"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:contentDescription="@string/btn_editChoice"
-            android:src="@drawable/ic_action_edit" />
+    <ImageButton
+        android:id="@+id/choice_remove_btn"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/btn_deleteChoice"
+        android:src="@drawable/ic_action_discard" 
+        android:layout_weight="1"
+        android:layout_marginRight="5dp"/>
 
-        <ImageButton
-            android:id="@+id/choice_remove_btn"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:contentDescription="@string/btn_deleteChoice"
-            android:src="@drawable/ic_action_discard" />
-    </LinearLayout>
-
-</FrameLayout>
+</LinearLayout>


### PR DESCRIPTION
If you used autocorrect in the text edit field the core android stuff would break with an arrayIndexOutOfBounds exception. Removed the length limit and adjust view to compensate. Now no more limit on choice text length.
